### PR TITLE
feat: mybatis 설정 및 도메인별 mapper 분리 구조 적용

### DIFF
--- a/livecommerce-server/src/main/resources/application.yml
+++ b/livecommerce-server/src/main/resources/application.yml
@@ -4,10 +4,19 @@ spring:
     url: ${DB_URL}
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
+
   jpa:
     database: mysql
     database-platform: org.hibernate.dialect.MySQL8Dialect
     generate-ddl: true
     hibernate:
-      ddl-auto: create
-    show_sql: true
+      ddl-auto: validate         # create | update | validate | none 중 선택
+    show-sql: true
+
+
+mybatis:
+  mapper-locations: classpath:mapper/**/*.xml
+  type-aliases-package: com.example.livecommerce_server   # resultType, parameterType 등에서 패키지명을 생략하고 클래스 이름만 사용 가능하게 해주는 설정
+                                                          # 이 패키지 아래에 있는 DTO/VO 클래스들이 자동으로 별칭 등록됨
+  configuration:                         # DB 컬럼명이 user_id처럼 snake_case인 경우,
+    map-underscore-to-camel-case: true  # 자바 필드명이 userId처럼 camelCase여도 자동으로 매핑해주는 설정

--- a/livecommerce-server/src/main/resources/mapper/chat/test.xml
+++ b/livecommerce-server/src/main/resources/mapper/chat/test.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+</beans>


### PR DESCRIPTION
### ✅ PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ x ] 환경/빌드/의존성 수정

### 📝 변경 내용
- application.yml에 mybatis 설정 추가
  - mapper-locations, type-aliases-package, camelCase 자동 매핑 설정
- resources/mapper 디렉토리 구조 정비
  - user, product, chat 등 도메인별 하위 폴더로 매퍼 파일 분리
- 설정 주석 추가로 팀원 이해도 향상

### 🔍 체크리스트
- [ ] 코드 스타일 가이드 준수
- [ ] 커밋 컨벤션 준수
- [ ] 기능/버그 테스트 완료
- [ ] 최신 브랜치 pull 후 PR

### 🔗 관련 이슈


