### PR TITLE
feature:상품 상세페이지 -> 주문페이지 쿼리 연결!

### DIFF
--- a/livecommerce-front/src/components/inc-dec.vue
+++ b/livecommerce-front/src/components/inc-dec.vue
@@ -5,7 +5,8 @@
                 <path d="M10.4361 0.203613H12.0736L7.81774 0.203615H13.8729V1.80309H7.81774L3.50809 1.80309H1.87053L6.18017 1.80309H0.125V0.203615H6.18017L10.4361 0.203613Z"/>
             </svg>
         </button>
-        <input class="w-6 h-auto outline-none bg-transparent text-base mg:text-lg leading-none text-title dark:text-white text-center" type="text" :value="count">
+<!--        <input class="w-6 h-auto outline-none bg-transparent text-base mg:text-lg leading-none text-title dark:text-white text-center" type="text" :value="count">-->
+        <input v-model="count" class="w-6 h-auto outline-none bg-transparent text-base mg:text-lg leading-none text-title dark:text-white text-center" type="text"/>
         <button @click="increment" class="inc  w-8 h-8 bg-[#E8E9EA] dark:bg-dark-secondary flex items-center justify-center">
             <svg class="fill-current text-title dark:text-white" width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <path d="M6.18017 0.110352H7.81774V6.16553H13.8729V7.76501H7.81774V13.8963H6.18017V7.76501H0.125V6.16553H6.18017V0.110352Z"/>
@@ -15,16 +16,34 @@
 </template>
 
 <script setup>
-    import { ref } from 'vue';
+    import { computed, defineProps, defineEmits } from 'vue';
+    const props = defineProps({
+      modelValue:{
+        type: Number,
+        default:1
+      }
+    })
 
-    const count = ref(3)
+    const emit = defineEmits(['update:modelValue'])
 
-    const increment = () => {
-        count.value++
+    const count = computed({
+      get() {
+        return props.modelValue
+      },
+      set(val) {
+        const next = val < 1 ? 1 : val
+        emit('update:modelValue', next)
+      }
+    })
+
+    // 4. 버튼 클릭 시 count 조작
+    function increment() {
+      count.value++
     }
-    const decrement = () => {
-        if(count.value > 0){
-            count.value--
-        }
+
+    function decrement() {
+      if (count.value > 1) {
+        count.value--
+      }
     }
 </script>

--- a/livecommerce-front/src/router/index.js
+++ b/livecommerce-front/src/router/index.js
@@ -120,7 +120,15 @@ const routes = [
 
   {path: '/auth-test',component: AuthTest},
   {path: '/chat-test',component: ChatTest},
-  {path: '/order',component: OrderView},
+  {
+    path: '/order',
+    name: 'Order',
+    component: OrderView,
+    props: route => ({
+      productId: route.query.productId,
+      quantity: Number(route.query.quantity) || 1
+    }),
+  },
   {path: '/order-confirmation',component: OrderConfirmationView},
   {path: '/order-history',component: OrderHistoryView},
   {path: '/partner/order-history',component: PartnerOrderHistoryView},
@@ -157,7 +165,8 @@ const routes = [
       {
         path: 'product/detail/:id',
         name: 'AdminProductDetail',
-        component: () => import('@/modules/product/views/AdminProductDetail.vue')
+        component: () => import('@/modules/product/views/AdminProductDetail.vue'),
+        props : true
       }
     ],
   },

--- a/livecommerce-front/src/views/shop/product-details.vue
+++ b/livecommerce-front/src/views/shop/product-details.vue
@@ -71,10 +71,17 @@
             </div>
 
             <div class="py-4 sm:py-6 border-b border-bdr-clr dark:border-bdr-clr-drk" data-aos="fade-up">
-              <IncDec />
+              <IncDec v-model="quantity" />
               <div class="flex gap-4 mt-4 sm:mt-6">
                 <router-link to="/cart" class="btn btn-outline">장바구니</router-link>
-                <router-link to="#" class="btn btn-outline">구매</router-link>
+                <router-link :to="{
+                path: '/order',
+                query: {
+                  productId: data?.id,
+                  quantity
+                }
+                }" class="btn btn-outline">
+                  구매</router-link>
               </div>
             </div>
           </div>
@@ -108,10 +115,20 @@ onMounted(() => {
   Aos.init();
 });
 
+// inc-dec 수량 변경 테스트
+const quantity = ref(1);
+
+watch(
+    quantity,
+    () => { /* no-op or console.log */ },
+    { flush: 'sync' }
+);
+
 const activeImage = ref(1);
 const now = ref(new Date().getTime());
 const targetTime = ref(new Date('Sep 13 2025').getTime());
 const difference = ref(0);
+
 
 const days = computed(() => Math.floor(difference.value / (1000 * 60 * 60 * 24)));
 const hours = computed(() => 23 - new Date(now.value).getHours());


### PR DESCRIPTION
### ✅ PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 환경/빌드/의존성 수정

### 📝 변경 내용
- 상품 상세페이지의 product_id와 수량 데이터를 가지고 주문 페이지로 넘어갈 수 있도록 쿼리 파라미터와 vue script 작업

### 🔍 체크리스트
- [x] 코드 스타일 가이드 준수
- [x] 커밋 컨벤션 준수
- [x] 기능/버그 테스트 완료
- [x] 최신 브랜치 pull 후 PR

### ✏️ 참고 사항 _(Optional)_
- 실제 상품ID를 기반으로 주문 페이지 구성 예정